### PR TITLE
require version 5.2 of guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	],
 	"require": {
 		"php": ">=5.4.0",
-		"guzzlehttp/guzzle": "~4.0"
+		"guzzlehttp/guzzle": "~5.2"
 	},
 	"require-dev": {
 		"phpspec/phpspec": "~2.0"

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,15 @@ $spreedly = new Tuurbo\Spreedly\Spreedly($config);
 $resp = $spreedly->payment(...)->purchase(4.99);
 ```
 
+If you put your configs into `config/services.php` then you can do:
+
+```
+$spreedly = new Spreedly( config('services.spreedly') );
+
+$resp = $spreedly->payment(...)->purchase(4.99);
+
+```
+
 ## Example response handling
 
 ```


### PR DESCRIPTION
I'm no expert of composer, but it's possible that the contributors of tuurbo/spreedly haven't run a composer update in a while and didn't realize that guzzle 4.0 is unavailable. By changing it to require guzzle 5.2 there are no longer issues installing tuurbo/spreedly with `composer update`.

I tested it by changing my composer file to:

```
    ...
    "repositories":
    [
        {
            "type": "vcs",
            "url": "https://github.com/fattmerchantorg/spreedly"
        }
    ],
    "require": {
        "laravel/framework": "5.0.*",
        "tuurbo/spreedly": "dev-master",
        ...
```
