### PR TITLE
Ability to merge configs in addition to setting them

### DIFF
--- a/src/Spreedly.php
+++ b/src/Spreedly.php
@@ -92,7 +92,7 @@ class Spreedly
      */
     public function mergeConfig(array $config)
     {
-        $this->config = array_merge($this->config, $config);
+        $this->config = array_merge($this->config ?: [], $config);
 
         $this->validateConfig();
 

--- a/src/Spreedly.php
+++ b/src/Spreedly.php
@@ -80,6 +80,26 @@ class Spreedly
     }
 
     /**
+     * Merge config.
+     *
+     * Given an array of configs, they will be merged into the existing config
+     * instead of replacing them completely
+     * The supplied configs are given priority.
+     * 
+     * @param array $config
+     *
+     * @return $this
+     */
+    public function mergeConfig(array $config)
+    {
+        $this->config = array_merge($this->config, $config);
+
+        $this->validateConfig();
+
+        return $this;
+    }
+
+    /**
      * Check config for required params.
      */
     protected function validateConfig()


### PR DESCRIPTION
```PHP
Spreedly::mergeConfig( $spreedlyConfig );
```

This is an alternative to `setConfig()`.

Given an array of configs, they will be merged into the existing config instead of replacing them completely. The supplied configs are given priority.

In my specific case I have a whole table with multiple gateways and I have been building the config object outside of `tuurbo/spreedly` and using `setConfig`. However, now that I need to support the timeouts I decided to use the `services.spreedly` config and I don't want to override those defaults. My solution was to be able to merge them.

I did not write a unit test because I didn't see you using `setConfig` in any tests. 