### PR TITLE
Upgraded container binding for Laravel 5.4 support

### DIFF
--- a/src/SpreedlyServiceProvider.php
+++ b/src/SpreedlyServiceProvider.php
@@ -15,13 +15,13 @@ class SpreedlyServiceProvider extends ServiceProvider
 
     /**
      * Register the service provider.
+     *
+     * @return void
      */
     public function register()
     {
-        $this->app['spreedly'] = $this->app->share(function ($app) {
-            $config = $app['config']->get('services.spreedly');
-
-            return new Spreedly($config);
+        $this->app->singleton('spreedly', function ($app) {
+            return new Spreedly($app['config']->get('services.spreedly'));
         });
     }
 


### PR DESCRIPTION
The share-method is a legacy method that hasn't been documented for some years, and it was completely removed in L5.4. 

[Laravel Upgrade Docs](https://laravel.com/docs/5.4/upgrade#upgrade-5.4.0)