### PR TITLE
Always return an array for client  errors()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -210,7 +210,7 @@ class Client
     public function errors($string = false)
     {
         if (!isset($this->response['errors'])) {
-            return;
+            return $string ? '' : [];
         }
 
         $errors = is_array($this->response['errors']) ? $this->response['errors'] : [$this->response['errors']];


### PR DESCRIPTION
in the case where there are no errors, keep with the purpose of this method and return either a string or an array instead of returning void.

before this patch, is Spreedly was down or not reachable and there were no errors it was returning void, but an array had been expected... so code like this was not working:

```php
$errors = $pm->errors();

return array_pluck($errors, 'message');

```

without this patch, a workaround is required:

```php
$errors = $pm->errors();

// new relic said sometimes $errors isn't an array
// which is silly because it comes from tuurbo\spreedly\client 
// which is supposed to always return an array...
// but sometimes it will just be nothing since it looks like if
// a network error occurs it will be empty
if (!is_array($errors))
{
    throw new Exception('Spreedly Errors were not in array format');
}

return array_pluck($errors, 'message');

```