### PR TITLE
Make sure capture currency does not default to USD

### DIFF
--- a/spec/Tuurbo/Spreedly/TransactionSpec.php
+++ b/spec/Tuurbo/Spreedly/TransactionSpec.php
@@ -114,9 +114,7 @@ class TransactionSpec extends ObjectBehavior
     public function it_captures_an_authorized_amount($client)
     {
         $data = [
-            'transaction' => [
-                'currency_code' => 'USD',
-            ],
+            'transaction' => [],
         ];
 
         $client->post('v1/transactions/'.self::TRANSACTION_TOKEN.'/capture.json', $data)
@@ -133,7 +131,6 @@ class TransactionSpec extends ObjectBehavior
         $data = [
             'transaction' => [
                 'amount' => $amount,
-                'currency_code' => 'USD',
             ],
         ];
 
@@ -142,6 +139,25 @@ class TransactionSpec extends ObjectBehavior
             ->willReturn($client);
 
         $this->capture($amount)->shouldReturnAnInstanceOf('Tuurbo\Spreedly\Client');
+    }
+
+    public function it_captures_a_specific_authorized_amount_and_currency($client)
+    {
+        $amount = 9.99;
+        $currencyCode = 'USD';
+
+        $data = [
+            'transaction' => [
+                'amount' => $amount,
+                'currency_code' => $currencyCode,
+            ],
+        ];
+
+        $client->post('v1/transactions/'.self::TRANSACTION_TOKEN.'/capture.json', $data)
+            ->shouldBeCalled()
+            ->willReturn($client);
+
+        $this->capture($amount, $currencyCode)->shouldReturnAnInstanceOf('Tuurbo\Spreedly\Client');
     }
 
     public function it_completes_a_3ds2_transaction($client)

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -151,13 +151,15 @@ class Transaction
      *
      * @return \Tuurbo\Spreedly\Client
      */
-    public function capture($amount = null, $currency = 'USD', array $data = [])
+    public function capture($amount = null, $currency = null, array $data = [])
     {
         $params = [
-            'transaction' => [
-                'currency_code' => $currency,
-            ],
+            'transaction' => [],
         ];
+
+        if ($currency !== null) {
+            $params['transaction']['currency_code'] = $currency;
+        }
 
         if ($amount > 0) {
             $params['transaction']['amount'] = $amount;


### PR DESCRIPTION
👋

This is a fix for a bug around the `Transaction::capture` method.

## Problem

When an authorization is taken in a currency other than USD (eg GBP), currently when `Transaction::capture` is called without any arguments it causes Spreedly to attempt to capture with the amount that was authorized but with the currency set as USD rather than the currency authorized. This is caused by the `$currency` argument of the capture method being defaulted to USD when no value is passed in.

## Steps to reproduce

```php
$spreedly = new Tuurbo\Spreedly\Spreedly([config...]);

$transactionToken = $spreedly->payment()->authorize(12345, 'GBP')->transactionToken();

$spreedly->transaction($transactionToken)->capture();
``` 

This currenctly causes Spreedly to attempt to capture a payment with the value of 12345 USD rather than the expected 12345 GBP. According to [Spreedlys docs](https://docs.spreedly.com/reference/api/v1/#full-amount) sending no arguments to capture endpoint should just capture the amount and currency of the authorisation that was performed.