### PR TITLE
Allow changing spreedly base url in config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4 @@
+{
+  "name": "spreedly",
+  "lockfileVersion": 1
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,0 @@
-{
-  "name": "spreedly",
-  "lockfileVersion": 1
-}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "name": "spreedly",
-  "version": "1.0.0",
-  "description": "**[changelog](#changelog) !! As of the 2.0 release the amount must be an integer as required by Spreedly. E.g., 1098 for $10.98 !!**",
-  "main": "index.js",
+  "description": "A simple php sdk for Spreedly.com's API.",
   "directories": {
     "doc": "docs"
   },
@@ -12,13 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/fattmerchantorg/spreedly.git"
+    "url": "git+https://github.com/tuurbo/spreedly.git"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "https://github.com/tuurbo",
+  "license": "MIT",
   "bugs": {
-    "url": "https://github.com/fattmerchantorg/spreedly/issues"
+    "url": "https://github.com/tuurbo/spreedly/issues"
   },
-  "homepage": "https://github.com/fattmerchantorg/spreedly#readme"
+  "homepage": "https://github.com/tuurbo/spreedly#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "spreedly",
+  "version": "1.0.0",
+  "description": "**[changelog](#changelog) !! As of the 2.0 release the amount must be an integer as required by Spreedly. E.g., 1098 for $10.98 !!**",
+  "main": "index.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "vendor/bin/phpspec run",
+    "install": "composer install"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fattmerchantorg/spreedly.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/fattmerchantorg/spreedly/issues"
+  },
+  "homepage": "https://github.com/fattmerchantorg/spreedly#readme"
+}

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,11 @@
-**[changelog](#changelog) !! As of the 2.0 release the amount must be an integer as required by Spreedly. E.g., 1098 for $10.98 !!**
+**[changelog](#changelog) !! As of the 2.0 release the amount must be an integer as required by Spreedly. E.g., 1098 for \$10.98 !!**
 
 # Getting Started
 
 ## Setup/Install
 
 Install through Composer.
+
 ```
 composer require tuurbo/spreedly
 ```
@@ -28,6 +29,7 @@ Next, update app/config/app.php to include a reference to this package's service
 [Login](https://spreedly.com) to your Spreedly account to retrieve your api credentials. You can set your default gateway once you've created your first gateway.
 
 Add to app/config/services.php config file.
+
 ```php
 return [
 
@@ -136,21 +138,41 @@ Spreedly::transaction()->capture();
 Spreedly::transaction()->complete();
 ```
 
+## Development
+
+Clone the repo and run `npm install`. This will `composer install`.
+
+**Testing**
+
+Tests are in the spec directory. They are written with [phpspec](https://www.phpspec.net/en/stable/).
+
+To run your tests, simply do `npm test`. If you don't want to use npm, that's fine, simply run `vendor/bin/phpspec run`
+
+Please ensure you have added proper test coverage for each Pull Request.
+
 ## Changelog
 
+### 2.3.1
+
+- added support for overriding the Spreedly base url
+
 ### 2.3
+
 - added support for laravel 5.4
 
 ### 2.2
+
 - added ability to merge configs.
 
 ### 2.1
+
 - changed default timeout from 15 seconds to 64 seconds as recommended by Spreedly.
-- added timeout method to change timeout per api call. E.g., ```Spreedly::timeout(25)->payment()->purchase()```.
-- added new ```Tuurbo\Spreedly\Exceptions\TimeoutException``` for catching timeouts.
+- added timeout method to change timeout per api call. E.g., `Spreedly::timeout(25)->payment()->purchase()`.
+- added new `Tuurbo\Spreedly\Exceptions\TimeoutException` for catching timeouts.
 
 ### 2.0
+
 - amount is no longer converted to cents.
-    - the amount must be an integer as required by Spreedly. E.g., 1098 for $10.98
+  - the amount must be an integer as required by Spreedly. E.g., 1098 for \$10.98
 - switched from Spreedly xml api to json api.
-- renamed ```->declined()``` method to ```->message()```.
+- renamed `->declined()` method to `->message()`.

--- a/spec/Tuurbo/Spreedly/ClientSpec.php
+++ b/spec/Tuurbo/Spreedly/ClientSpec.php
@@ -147,6 +147,29 @@ class ClientSpec extends ObjectBehavior
         $this->shouldThrow('Exception')
             ->duringGet(self::END_POINT);
     }
+
+    public function it_should_allow_overriding_the_base_url($client)
+    {
+        // for this test, reconstruct the client with the new base url
+        $overrideBaseUrl = 'https://otherdomain.com/';
+
+        $config = [
+            'key' => '12345',
+            'secret' => '67890',
+            'baseUrl' => $overrideBaseUrl
+        ];
+
+        $this->beConstructedWith($client, $config);
+
+        // check that client really did use the overriden base url
+        $client->post($overrideBaseUrl.self::END_POINT, Argument::type('array'))
+            ->shouldBeCalled()
+            ->willReturn(new ClientStub200());
+
+        $this->post(self::END_POINT)
+            ->success()
+            ->shouldReturn(true);
+    }
 }
 
 class ClientStub200 extends GuzzleResponse

--- a/src/Client.php
+++ b/src/Client.php
@@ -27,8 +27,7 @@ class Client
     public function __construct(GuzzleInterface $client, $config)
     {
         // allow overriding BASE_URL
-        if (!isset($config['baseUrl']))
-        {
+        if (!isset($config['baseUrl'])) {
             $config['baseUrl'] = self::BASE_URL;
         }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,6 +26,12 @@ class Client
      */
     public function __construct(GuzzleInterface $client, $config)
     {
+        // allow overriding BASE_URL
+        if (!isset($config['baseUrl']))
+        {
+            $config['baseUrl'] = self::BASE_URL;
+        }
+
         $this->client = $client;
         $this->config = $config;
     }
@@ -57,7 +63,9 @@ class Client
     protected function request($url, $method, array $data = null)
     {
         try {
-            $response = $this->client->{$method}(self::BASE_URL.$url, $this->buildData($data));
+            $baseUrl = $this->config['baseUrl'];
+
+            $response = $this->client->{$method}($baseUrl.$url, $this->buildData($data));
 
             if (!in_array($response->getStatusCode(), [200, 201])) {
                 $contentType = $response->getHeader('Content-Type');


### PR DESCRIPTION
Addresses Issue #30 

In order to support a proxy service or other scenarios, this PR allows the base url to not be spreedly. 

This is a simple change on the Client.php class. 

Example use:

```
$spreedlyConfig = [
    "baseUrl" => "http://someproxy.com/",
    "key" => "aaaaa",
    "secret" => "bbbbb"
];

Spreedly::setConfig($spreedlyConfig); // - OR - 
Spreedly::mergeConfig($spreedlyConfig);
```

The default value is still the real Spreedly api url. 

-----

This PR also enhances the readme with some development and testing instructions.

It also adds a very simple `package.json` which helps with install and running tests.

```npm install
npm test // simply runs phpspec
```